### PR TITLE
Switch to worker pool for event handling and update version number

### DIFF
--- a/sandwich/sandwich.go
+++ b/sandwich/sandwich.go
@@ -21,7 +21,7 @@ import (
 )
 
 // VERSION follows semantic versioning.
-const VERSION = "1.0.4"
+const VERSION = "1.1"
 
 var LastRequestTimeout = time.Minute * 60
 

--- a/sandwich/sandwich.go
+++ b/sandwich/sandwich.go
@@ -21,7 +21,7 @@ import (
 )
 
 // VERSION follows semantic versioning.
-const VERSION = "1.1"
+const VERSION = "1.1.0"
 
 var LastRequestTimeout = time.Minute * 60
 


### PR DESCRIPTION
Implement a worker pool based on shard_id to maintain event ordering per shard. Update the version number to reflect the changes.